### PR TITLE
Guard against missing props

### DIFF
--- a/static/js/components/GodForm.js
+++ b/static/js/components/GodForm.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { titleCase } from "voca";
 
 const XX = "XX";
@@ -25,6 +26,10 @@ const ChromosomesSelector = props => (
     </select>
   </div>
 );
+ChromosomesSelector.propTypes = {
+  chromosomes: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired
+};
 
 const GenderSelector = props => (
   <div className="pantheon-form-item">
@@ -43,24 +48,35 @@ const GenderSelector = props => (
     </select>
   </div>
 );
+GenderSelector.propTypes = {
+  gender: PropTypes.string.isRequired,
+  chromosomes: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired
+};
 
 const SeedWordInputter = props => (
   <div className="pantheon-form-item">
     <label htmlFor={props.name}>{props.label}</label>
     <input
       type="text"
-      placeholder={props.placeholder || ""}
+      placeholder={props.seedWord || ""}
       name={props.name}
       onChange={props.onChange}
     />
   </div>
 );
+SeedWordInputter.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  seedWord: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired
+};
 
 export default class GodForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      chromosomes: this.props.defaultChromosomes || XX,
+      chromosomes: this.props.chromosomes || XX,
       gender: "",
       seedWordA: "",
       seedWordB: ""
@@ -109,16 +125,21 @@ export default class GodForm extends React.Component {
         <SeedWordInputter
           name="seedWordA"
           label="A Domain (a word like Art)"
-          placeholder={this.state.seedWordA}
+          seedWord={this.state.seedWordA}
           onChange={this.handleChange}
         />
         <SeedWordInputter
           name="seedWordB"
           label="Another Domain (a word like Science)"
-          placeholder={this.state.seedWordB}
+          seedWord={this.state.seedWordB}
           onChange={this.handleChange}
         />
       </div>
     );
   }
 }
+
+GodForm.propTypes = {
+  chromosomes: PropTypes.string,
+  godID: PropTypes.string.isRequired
+};

--- a/static/js/components/PantheonForm.js
+++ b/static/js/components/PantheonForm.js
@@ -20,6 +20,11 @@ const NamesSourceSelector = props => (
     </select>
   </div>
 );
+NamesSourceSelector.propTypes = {
+  namesSource: PropTypes.string.isRequired,
+  sourcesOfNames: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired
+};
 
 const TextsSourceSelector = props => (
   <div className="pantheon-form-item">
@@ -37,17 +42,28 @@ const TextsSourceSelector = props => (
     </select>
   </div>
 );
+TextsSourceSelector.propTypes = {
+  textsSource: PropTypes.string.isRequired,
+  sourcesOfTexts: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired
+};
 
 const GodOfCreationForm = props => (
   <div>
     <div className="pantheon-form-description">{props.description}</div>
     <GodForm
-      defaultChromosomes={props.defaultChromosomes}
+      chromosomes={props.chromosomes}
       godID={props.godID}
       onChange={props.onChange}
     />
   </div>
 );
+GodOfCreationForm.propTypes = {
+  description: PropTypes.string.isRequired,
+  chromosomes: PropTypes.string.isRequired,
+  godID: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired
+};
 
 export default class PantheonForm extends React.Component {
   constructor(props) {
@@ -87,7 +103,7 @@ export default class PantheonForm extends React.Component {
       godA: this.state.godA,
       godB: this.state.godB
     };
-    this.props.fetchPantheon(options);
+    this.props.onSubmit(options);
   }
 
   render() {
@@ -97,13 +113,13 @@ export default class PantheonForm extends React.Component {
           <h4>Parents of Creation</h4>
 
           <GodOfCreationForm
-            defaultChromosomes={GodForm.XX}
+            chromosomes={GodForm.XX}
             onChange={this.updateGod}
             godID={"godA"}
             description={"1st God of Creation"}
           />
           <GodOfCreationForm
-            defaultChromosomes={GodForm.XY}
+            chromosomes={GodForm.XY}
             onChange={this.updateGod}
             godID={"godB"}
             description={"2nd God of Creation"}
@@ -132,5 +148,6 @@ export default class PantheonForm extends React.Component {
 
 PantheonForm.propTypes = {
   sourcesOfNames: PropTypes.array.isRequired,
-  sourcesOfTexts: PropTypes.array.isRequired
+  sourcesOfTexts: PropTypes.array.isRequired,
+  onSubmit: PropTypes.func.isRequired
 };

--- a/static/js/containers/PantheonContainer.js
+++ b/static/js/containers/PantheonContainer.js
@@ -46,7 +46,7 @@ export default class PantheonContainer extends React.Component {
       <div>
         <section>
           <PantheonForm
-            fetchPantheon={this.fetchPantheon}
+            onSubmit={this.fetchPantheon}
             sourcesOfNames={this.fetchSourcesOfNames()}
             sourcesOfTexts={this.fetchSourcesOfTexts()}
           />


### PR DESCRIPTION
# Goal

Add `.propTypes` to every form component so that missing and miss-named required props will produce warnings. (It'd be awfully easy to pass the prop `godId` to a `GodOfCreationForm` but now the form requires a `godID` so React will warn me.)